### PR TITLE
feat: enlarge carousel images in modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,12 @@
     </div>
   </div>
 
+  <!-- Visor de imagen a tamaño completo -->
+  <div class="img-modal" id="imgModal" role="dialog" aria-modal="true">
+    <button class="img-modal-close" id="imgModalClose" aria-label="Cerrar imagen">✕</button>
+    <img id="imgModalImg" alt="" />
+  </div>
+
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
 
@@ -87,6 +93,12 @@
         const update=()=>{ track.style.transform=`translateX(-${idx*100}%)`; };
         prev.addEventListener('click',()=>{ idx=(idx-1+imgs.length)%imgs.length; update(); });
         next.addEventListener('click',()=>{ idx=(idx+1)%imgs.length; update(); });
+        imgs.forEach(img=>{
+          img.tabIndex=0;
+          img.setAttribute('role','button');
+          img.addEventListener('click',()=>openImgModal(img.src,img.alt));
+          img.addEventListener('keydown',e=>{ if(e.key==='Enter' || e.key===' ') openImgModal(img.src,img.alt); });
+        });
         update();
       });
     }
@@ -95,6 +107,10 @@
     const modalBody=document.getElementById('modalBody');
     const modalTitle=document.getElementById('modalTitle');
     const closeBtn=document.getElementById('modalClose');
+
+    const imgModal=document.getElementById('imgModal');
+    const imgModalImg=document.getElementById('imgModalImg');
+    const imgModalClose=document.getElementById('imgModalClose');
     function openModal(idx){
       const tmpl=document.getElementById('pet-detail-'+idx);
       if(!tmpl) return;
@@ -112,7 +128,28 @@
     }
     closeBtn.addEventListener('click',closeModal);
     modal.addEventListener('click',e=>{ if(e.target===modal) closeModal(); });
-    window.addEventListener('keydown',e=>{ if(e.key==='Escape'&&modal.classList.contains('open')) closeModal(); });
+
+    function openImgModal(src,alt=''){
+      imgModalImg.src=src;
+      imgModalImg.alt=alt;
+      imgModal.classList.add('open');
+      document.body.classList.add('no-scroll');
+      imgModalClose.focus();
+    }
+    function closeImgModal(){
+      imgModal.classList.remove('open');
+      imgModalImg.src='';
+      if(!modal.classList.contains('open')) document.body.classList.remove('no-scroll');
+    }
+    imgModalClose.addEventListener('click',closeImgModal);
+    imgModal.addEventListener('click',e=>{ if(e.target===imgModal||e.target===imgModalImg) closeImgModal(); });
+
+    window.addEventListener('keydown',e=>{
+      if(e.key==='Escape'){
+        if(imgModal.classList.contains('open')) closeImgModal();
+        else if(modal.classList.contains('open')) closeModal();
+      }
+    });
 
     fetch('pets.json')
       .then(r=>r.json())

--- a/styles/index.css
+++ b/styles/index.css
@@ -95,10 +95,17 @@ h1{margin:0;font:800 28px/1.1 Poppins,Inter,sans-serif;letter-spacing:.2px}
 /* Carousel */
 .carousel{position:relative;aspect-ratio:4/3;overflow:hidden;background:#0a1225;}
 .carousel .track{display:flex;height:100%;transition:transform .3s ease;}
-.carousel img{width:100%;height:100%;object-fit:cover;object-position:center 42%;flex-shrink:0;}
+.carousel img{width:100%;height:100%;object-fit:cover;object-position:center 42%;flex-shrink:0;cursor:zoom-in;}
 .carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(0,0,0,.4);color:#fff;border:0;width:32px;height:32px;border-radius:50%;cursor:pointer;}
 .carousel .prev{left:10px;}
 .carousel .next{right:10px;}
+
+/* Modal de imagen completa */
+.img-modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.85);z-index:50;padding:20px;}
+.img-modal.open{display:flex;}
+.img-modal img{max-width:100%;max-height:100%;object-fit:contain;cursor:zoom-out;}
+.img-modal-close{position:absolute;top:18px;right:18px;background:rgba(0,0,0,.5);color:#fff;border:0;border-radius:50%;width:36px;height:36px;font-size:1.2rem;cursor:pointer;}
+.img-modal-close:focus{box-shadow:var(--ring);outline:none}
 
 /* ===== Mobile tweaks ===== */
 @media (max-width:820px){
@@ -117,6 +124,8 @@ h1{margin:0;font:800 28px/1.1 Poppins,Inter,sans-serif;letter-spacing:.2px}
     .modal-card{width:100%;height:100vh;max-height:none;border-radius:0}
     .modal-body{padding:14px}
     .detail-grid{grid-template-columns:1fr;gap:16px}
+    .img-modal{padding:10px}
+    .img-modal-close{top:10px;right:10px}
   /* no hover animation on touch */
 }
 


### PR DESCRIPTION
## Summary
- add full-screen image viewer modal for carousel photos
- enable keyboard and click interactions to open viewer
- style image viewer for desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a73db4083338c15f5741388b75e